### PR TITLE
potential vulnerability with rm with systems that do not implement --no-preserve-root

### DIFF
--- a/scripts/build-antivirus-from-source.sh
+++ b/scripts/build-antivirus-from-source.sh
@@ -4,8 +4,7 @@ set -e
 GIT_DIR=/tmp/bucket-antivirus-function
 AMZ_LINUX_VERSION=2
 
-mkdir -p $GIT_DIR
-rm -rf $GIT_DIR/*
+rm -rf $GIT_DIR
 
 git clone https://github.com/upsidetravel/bucket-antivirus-function.git $GIT_DIR
 


### PR DESCRIPTION
now if GIT_DIR is eventually not set rm -rf won't do anything and script will fail later